### PR TITLE
Update Dockerfile to k3s version 1.29.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ VOLUME /var/log
 ENV PATH="$PATH:/bin/aux"
 ENV CRI_CONFIG_FILE="/var/lib/rancher/k3s/agent/etc/crictl.yaml"
 
-COPY --from=rancher/k3s:v1.25.3-k3s1 /bin /bin
+COPY --from=rancher/k3s:v1.29.1-k3s1 /bin /bin
 
 COPY k3d-entrypoint-nfs.sh /bin/
 


### PR DESCRIPTION
Updated to the latest stable version. Also tested the new image locally and deployed full Azure IoT Operations Preview to validate all components still get deployed correctly.